### PR TITLE
update pip and debian help

### DIFF
--- a/content/post/mirror-help/debian.md
+++ b/content/post/mirror-help/debian.md
@@ -8,4 +8,6 @@ Debian 是完全由自由软件组成的类UNIX操作系统，其包含的多数
 
 使用方法：
 
-打开` /etc/apt/sources.list`，将类似于`http://deb.debian.org/debian/`的地址均替换为`https://mirrors.sjtug.sjtu.edu.cn/debian`即可。
+先安装 ca-certificates apt-transport-https 保证第三方https源可以使用。
+
+再打开` /etc/apt/sources.list`，将类似于`http://deb.debian.org/debian/`的地址均替换为`https://mirrors.sjtug.sjtu.edu.cn/debian`即可。

--- a/content/post/mirror-help/pypi.md
+++ b/content/post/mirror-help/pypi.md
@@ -8,7 +8,7 @@ Pypi是Python官方的包仓库，可以通过`pip`, `easy_install`等方式从p
 
 使用方法：
 
-创建或编辑`~/.pip/pip.conf`文件，加入或修改`index-url`相关段落为：
+创建或编辑`~/.config/pip/pip.conf`文件，加入或修改`index-url`相关段落为：
 
 ```conf
 [global]


### PR DESCRIPTION
ca-certificates apt-transport-https is needed for all apt mirrors I think.
also `~/.pip/pip.conf` is a legacy config path