### PR TITLE
add help docs for git/crates.io-index

### DIFF
--- a/content/post/mirror-help/creates.io.git.md
+++ b/content/post/mirror-help/creates.io.git.md
@@ -1,0 +1,19 @@
++++
+title = "git/crates.io-index"
+tags = ["mirror-help"]
+author = "skyzh"
+date = "2020-07-09T01:00:00+08:00"
++++
+
+
+编辑 `~/.cargo/config`
+
+```
+[source]
+
+[source.mirror]
+registry = "https://mirrors.sjtug.sjtu.edu.cn/git/crates.io-index/"
+
+[source.crates-io]
+replace-with = "mirror"
+```


### PR DESCRIPTION
This makes it less confusing when user click the hyperlink and gets a 404