### PR TITLE
fix: `debian-ports` not showing up

### DIFF
--- a/content/post/mirror-help/debian-ports.md
+++ b/content/post/mirror-help/debian-ports.md
@@ -1,5 +1,5 @@
 +++
-title = "debian"
+title = "debian-ports"
 tags = ["mirror-help"]
 author = "hmsjy2017"
 +++


### PR DESCRIPTION
Following https://github.com/sjtug/portal/pull/94/