### PR TITLE
mirror-help: update raspbian-addons

### DIFF
--- a/content/post/mirror-help/raspberry-pi-os-images.md
+++ b/content/post/mirror-help/raspberry-pi-os-images.md
@@ -75,7 +75,7 @@ author = "danyang685"
 
   ```shell
   wget -qO- https://mirror.sjtu.edu.cn/raspbian-addons/KEY.gpg | sudo apt-key add -
-  echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/raspbian-addons.list
+  echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian precise main" | sudo tee /etc/apt/sources.list.d/raspbian-addons.list
   sudo apt update
   ```
 

--- a/content/post/mirror-help/raspbian-addons.md
+++ b/content/post/mirror-help/raspbian-addons.md
@@ -20,7 +20,7 @@ wget -qO- https://mirror.sjtu.edu.cn/raspbian-addons/KEY.gpg | sudo apt-key add 
 ```
 添加该仓库
 ```bash
-echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian/ /" | sudo tee /etc/apt/sources.list.d/raspbian-addons.list
+echo "deb https://mirror.sjtu.edu.cn/raspbian-addons/debian precise main" | sudo tee /etc/apt/sources.list.d/raspbian-addons.list
 ```
 更新软件包缓存
 ```bash


### PR DESCRIPTION
由于上游修改了存储库目录结构，这里也要做出相应的修改。
https://github.com/raspbian-addons/raspbian-addons/issues/109