### PR TITLE
mirror-help: Add `.toml` for cargo config help file

### DIFF
--- a/content/post/mirror-help/crates.io.md
+++ b/content/post/mirror-help/crates.io.md
@@ -5,7 +5,7 @@ author = "skyzh"
 date = "2020-07-09T01:00:00+08:00"
 +++
 
-编辑 `~/.cargo/config`
+编辑 `~/.cargo/config.toml`
 
 ```
 [source]


### PR DESCRIPTION
According to [the cargo book](https://doc.rust-lang.org/cargo/reference/config.html):
> Support for the .toml extension was added in version 1.39 and is the preferred form.

We'd better update the help text for it.