### PR TITLE
mirror-help: fix bioconductor.md

### DIFF
--- a/content/post/mirror-help/bioconductor.md
+++ b/content/post/mirror-help/bioconductor.md
@@ -7,7 +7,10 @@ author = "MitsuhaMiyamizu"
 Bioconductor 为高通量基因组数据的分析和可视化提供开源工具。Bioconductor多数软件包采用R统计编程语言开发。Bioconductor 每年释出两个版本，并有活跃的用户社区。
 
 使用方法：
-Bioconductor 镜像源配置文件之一是 .Rprofile (linux 下位于 `~/.Rprofile`, Windows 下位于 `~\library\base\R\Rprofile` )。
+
+Bioconductor 镜像源配置文件之一是 `~/.Rprofile` 。
+
+注：R 的 `~` 在类 Unix 系统下为： `$HOME` （即 `~` ），在 Windows 下为： `%USERPROFILE%\Documents` ，具体路径可以在 R 中执行 `path.expand("~")` 查看。
 
 在该文件末尾添加如下语句或在R/RStudio终端下键入:
 


### PR DESCRIPTION
Fix the path to `.Rprofiel` on Windows.

Also submitted PR to MirrorZ: https://github.com/mirrorz-org/mirrorz-help/pull/128